### PR TITLE
Fixed css regeneration and dependency copying

### DIFF
--- a/lib/sass-rails-source-maps/sass_importer.rb
+++ b/lib/sass-rails-source-maps/sass_importer.rb
@@ -1,5 +1,5 @@
 module SassRailsSourceMaps
-  class SassImporter < Sprockets::SassImporter
+  class SassImporter < Sass::Rails::SassImporter
 
     def public_url(uri, sourcemap_dir = nil)
       source_maps_directory = sourcemap_dir ? sourcemap_dir.sub(Rails.root.join('public').to_s, '') : "/#{SOURCE_MAPS_DIRECTORY}"

--- a/lib/sass-rails-source-maps/sass_template.rb
+++ b/lib/sass-rails-source-maps/sass_template.rb
@@ -24,8 +24,8 @@ module SassRailsSourceMaps
         cache:               ::Rails.application.config.assets.debug,
         line_numbers:        ::Rails.application.config.sass.line_numbers,
         line_comments:       ::Rails.application.config.sass.line_comments,
-        importer:            SassImporter.new(context.pathname.to_s),
-        load_paths:          context.environment.paths.map { |path| SassImporter.new(path.to_s) },
+        importer:            SassImporter.new(context, context.pathname.to_s),
+        load_paths:          context.environment.paths.map { |path| SassImporter.new(context, path.to_s) },
         sprockets:           {
           context:     context,
           environment: context.environment


### PR DESCRIPTION
I encountered Problems with sass-rails-source-maps and my Setup (rails 4.1.7, source-maps 5.0.0-beta1, sass 3.4.9), specifically:

* Dependencies weren't copied to public directory, only `application.sccs` was copied, so other scss files couldn't be viewed in Browser
* Css files weren't regenerated when changes were made to the scss files

Based on https://github.com/gaijin1973/sass-rails-source-maps/commit/9bbc89b222ad9a3a7f908d9691b568e81076d057 I did some small changes and now it works again (at least in my small test environment).